### PR TITLE
allow artifact to work correctly when declared from multiple manifest…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,8 +34,9 @@ define artifact (
   validate_absolute_path($swap)
   validate_string($source)
   validate_string($title)
-  include artifact::install
-
+  if !defined(Class['artifact::install']) {
+    include artifact::install
+  }
   # Some overly scoped path to help functionality across platforms
   $path = '/bin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/share/bin:/usr/share/bin'
   $resource = $title
@@ -101,5 +102,3 @@ define artifact (
     subscribe => Exec["artifact ${resource}"]
   }
 }
-
-

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,24 @@
 # class artifact::install
 class artifact::install {
-  package { 'curl': ensure => installed }
+  if !defined(Package['curl']) {
+    package { 'curl': ensure => installed }
+  }
 
-  package { 'dos2unix': ensure => installed }
+  if !defined(Package['dos2unix']) {
+    package { 'dos2unix': ensure => installed }
+  }
 
-  package { 'grep': ensure => installed }
+  if !defined(Package['grep']) {
+    package { 'grep': ensure => installed }
+  }
 
-  package { 'diffutils': ensure => installed }
+  if !defined(Package['diffutils']) {
+    package { 'diffutils': ensure => installed }
+  }
 
-  package { 'bash': ensure => installed }
+  if !defined(Package['bash']) {
+    package { 'bash': ensure => installed }
+  }
 
   file { '/usr/local/sbin/artifact-puppet':
     ensure  => present,


### PR DESCRIPTION
When attempting to use artifact from multiple manifests, its firstly important to use the rename property which isn't too clear on the README.

Once using this parameter, there is an issue whereby it declares package resources for very commonly used packages as well as its own ::install class. This results in duplicate declaration of the same resources. This resolves those issues.
