### PR TITLE
Add Functionality for md5sum and file_line modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,18 @@ This module is designed to download artifacts using curl, the key feature is the
 
 ## Paramaeters
 
-  * $source  https://some_url.jar ```[required]```
-  * $target  /some/local/dir ```[required]```
-  * $update  override with newer ```[default: false]```
-  * $rename  rename the downloaded file ```[default: undef]```
-  * $purge   replace the target (alternative to updating) ```[default: false]```
-  * $swap    /download/dir ```[default: /tmp]```
-  * $timeout exit after $x seconds ```[default: 0]```
-  * $owner   uid owner of file ```[default: undef]```
-  * $group   gid owner of file ```[default: undef]```
-  * $mode    default permissions mode of file ```[default: undef]```
+  * $source   https://some_url.jar ```[required]```
+  * $target   /some/local/dir ```[required]```
+  * $update   override with newer ```[default: false]```
+  * $rename   rename the downloaded file ```[default: undef]```
+  * $purge    replace the target (alternative to updating) ```[default: false]```
+  * $swap     /download/dir ```[default: /tmp]```
+  * $timeout  exit after $x seconds ```[default: 0]```
+  * $owner    uid owner of file ```[default: undef]```
+  * $group    gid owner of file ```[default: undef]```
+  * $mode     default permissions mode of file ```[default: undef]```
+  * $validate default method to validate file ```[default: size]```
+  * $modified file modified elswhere in puppet ```[default: false]```
 
 ## Usage
 
@@ -63,7 +65,7 @@ artifact { "artifact-${version}-${build}.war":
 Command-Line usage of /usr/local/sbin/artifact-puppet:
 
 ```
-/usr/local/sbin/artifact-puppet /opt/wordpress.tar.gz https://wordpress.org/latest.tar.gz /tmp/wordpress.tar.gz
+/usr/local/sbin/artifact-puppet /opt/wordpress.tar.gz https://wordpress.org/latest.tar.gz /tmp/wordpress.tar.gz size false
 ```
 
 This will only compare if ARG1's size isn't the same as ARG2 and download it to ARG3, it only touches ARG1 & ARG3 if they don't exist.
@@ -71,7 +73,7 @@ This will only compare if ARG1's size isn't the same as ARG2 and download it to 
 ## Requirements
 
 ```
-package { ['curl', 'diffutils', 'grep', 'dos2unix']: ensure => 'installed' }
+package { ['curl', 'diffutils', 'grep', 'dos2unix', 'md5sum']: ensure => 'installed' }
 ```
 
 ## Compatibility

--- a/files/artifact-puppet
+++ b/files/artifact-puppet
@@ -1,33 +1,57 @@
 #!/bin/bash
-if [ "$#" -ne  "3" ]
+if [ "$#" -ne  "5" ]
 then
-    echo "Usage: artifact-puppet LOCAL_FILE REMOTE_FILE_URL SWAP_FILE"
+    echo "Usage: artifact-puppet LOCAL_FILE REMOTE_FILE_URL SWAP_FILE VERSION_TYPE MODIFIED"
     exit 2;
 else
 
     LOCAL=$1
     REMOTE=$2
     SWAP=$3
+    TYPE=$(echo $4| awk '{print tolower($0)}')
+    KEEP=$(echo $5| awk '{print tolower($0)}')
     
     if [ ! -f $LOCAL ]; then touch $LOCAL; fi
     if [ ! -f $SWAP ]; then touch $SWAP; fi
+
+    function export_ver {
+        if [ "$1" == "md5" ];
+        then
+            export LOCAL_VER=$(md5sum $LOCAL |awk '{print $1}')
+            REMOTE_VER=$(curl -s ${REMOTE}.md5)
+            if [ "$REMOTE_VER" == "" ];
+            then
+                echo "There was a problem downloading the md5 from $REMOTE so puppet will revert to size"
+                export_ver "size"
+            else
+                export REMOTE_VER
+            fi
+            export SWAP_VER=$(md5sum $SWAP|awk '{print $1}')
+        else
+            export LOCAL_VER=$(ls -l $LOCAL |awk '{print $5}'|dos2unix)
+            export REMOTE_VER=$(curl -sI $REMOTE|grep Length|awk '{print $2}'|dos2unix)
+            export SWAP_VER=$(ls -l $SWAP|awk '{print $5}'|dos2unix)
+        fi
+    }
     
-    export LOCAL_SIZE=$(ls -l $LOCAL |awk '{print $5}'|dos2unix)
-    export REMOTE_SIZE=$(curl -sI $REMOTE|grep Length|awk '{print $2}'|dos2unix)
-    export SWAP_SIZE=$(ls -l $SWAP|awk '{print $5}'|dos2unix)
     
-    if [ "$LOCAL_SIZE" == "$REMOTE_SIZE" ]; 
+    export_ver $TYPE
+    if [ "$LOCAL_VER" == "$REMOTE_VER" ]; 
     then 
-        echo "No Update Needed"
+        echo "No Update Needed: $TYPE Match"
+        exit 3;
+    elif [ "$SWAP_VER" == "$REMOTE_VER" ] && [ $KEEP == "true" ];
+    then
+        echo "No Update Needed: SWAP $TYPE Match and Modified $KEEP"
         exit 3;
     else 
-        if [ "$SWAP_SIZE" == "$REMOTE_SIZE" ];
+        if [ "$SWAP_VER" == "$REMOTE_VER" ];
         then
             echo "Update Ready in $SWAP"
         else
-            curl -so $SWAP $REMOTE
-            export SWAP_SIZE=$(ls -l $SWAP|awk '{print $5}'|dos2unix)
-            if [ "$SWAP_SIZE" == "$REMOTE_SIZE" ];
+            curl -sLo $SWAP $REMOTE
+            export_ver $TYPE
+            if [ "$SWAP_VER" == "$REMOTE_VER" ];
             then
                 echo "Update Ready in $SWAP"
             else

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,13 +27,16 @@ define artifact (
   $timeout = 0,
   $owner   = undef,
   $group   = undef,
-  $mode    = undef) {
+  $mode    = undef,
+  $validate = 'size',
+  $modified = false) {
   validate_bool($update)
   validate_bool($purge)
   validate_absolute_path($target)
   validate_absolute_path($swap)
   validate_string($source)
   validate_string($title)
+  validate_bool($modified)
   if !defined(Class['artifact::install']) {
     include artifact::install
   }
@@ -57,7 +60,7 @@ define artifact (
         path     => $path,
         provider => 'shell',
         command  => "rm -f  ${full_target} && yes|cp ${swap_target} ${full_target}",
-        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target}",
+        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target} ${validate} ${modified}",
         timeout  => $wait_sec,
         require  => File['/usr/local/sbin/artifact-puppet']
       }
@@ -66,7 +69,7 @@ define artifact (
         path     => $path,
         provider => 'shell',
         command  => "cp ${swap_target} ${full_target}",
-        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target}",
+        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target} ${validate} ${modified}",
         timeout  => $wait_sec,
         require  => File['/usr/local/sbin/artifact-puppet']
       }
@@ -77,7 +80,7 @@ define artifact (
         path     => $path,
         provider => 'shell',
         command  => "rm -f ${full_target} && mv -f ${swap_target} ${full_target}",
-        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target}",
+        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target} ${validate} ${modified}",
         timeout  => $wait_sec,
         require  => File['/usr/local/sbin/artifact-puppet']
       }
@@ -86,7 +89,7 @@ define artifact (
         path     => $path,
         provider => 'shell',
         command  => "mv -f ${swap_target} ${full_target}",
-        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target}",
+        onlyif   => "/usr/local/sbin/artifact-puppet ${full_target} ${source} ${swap_target} ${validate} ${modified}",
         timeout  => $wait_sec,
         require  => File['/usr/local/sbin/artifact-puppet']
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,12 +20,16 @@ class artifact::install {
     package { 'bash': ensure => installed }
   }
 
+  if !defined(Package['md5sum']) {
+    package { 'md5sum': ensure => installed }
+  }
+
   file { '/usr/local/sbin/artifact-puppet':
     ensure  => present,
     mode    => '0755',
     owner   => 'root',
     group   => 'root',
     source  => 'puppet:///modules/artifact/artifact-puppet',
-    require => [Package['dos2unix'], Package['curl'], Package['grep'], Package['bash']]
+    require => [Package['dos2unix'], Package['curl'], Package['grep'], Package['bash'], Package['md5sum']]
   }
 }


### PR DESCRIPTION
This pull request adds 2 features that I need.

1.  MD5 - use md5sum to calculate md5 of local and swap files,  downloads md5 from source for remote file by adding .md5 to uri.

2.  modified flag - if set to true,  and swap version already matches remote,  dont update file.  This prevents cycles of puppet replacing the file and using file_line to modify the file every time it runs,  and only pulls a new one when the version in swap is different from remote.

Limitations:
* remote must have a .md5 file,  if missing,  fails back to size
* if swap file stored on tempfs,  will always redownload on reboots and/or when tempfs clears.